### PR TITLE
Strip arbitrary-length escape sequences

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 'use strict';
 module.exports = function (str) {
-	return typeof str === 'string' ? str.replace(/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]/g, '') : str;
+	return typeof str === 'string' ? str.replace(/\x1B\[([0-9]{1,2}(;[0-9]{1,2})*)?[m|K]/g, '') : str;
 };

--- a/test.js
+++ b/test.js
@@ -7,6 +7,10 @@ it('should strip color from string', function () {
 	assert.equal(strip('\x1b[0m\x1b[4m\x1b[42m\x1b[31mfoo\x1b[39m\x1b[49m\x1b[24mfoo\x1b[0m'), 'foofoo');
 });
 
+it('should strip reset;setfg;setbg;italics;strike;underline sequence from string', function () {
+	assert.equal(strip('\x1b[0;33;49;3;9;4mbar\x1b[0m'), 'bar');
+});
+
 it('should strip color with CLI', function (done) {
 	exec('echo "\x1b[0m\x1b[4m\x1b[42m\x1b[31mfoo\x1b[39m\x1b[49m\x1b[24mfoo\x1b[0m" | ./cli.js', function (err, stdout) {
 		assert.equal(stdout, 'foofoo\n');


### PR DESCRIPTION
Valid escape sequences changing multiple attributes at once (see test) were failing 
to be stripped.

This pull request fixes the regex to strip these.
