### PR TITLE
Repaired a bug whereby color was not correctly stripped from the ls command

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 'use strict';
 module.exports = function (str) {
-	return typeof str === 'string' ? str.replace(/\x1B\[([0-9]{1,2}(;[0-9]{1,2})*)?[m|K]/g, '') : str;
+	return typeof str === 'string' ? str.replace(/\x1B\[([0-9]{1,3}(;[0-9]{1,3})*)?[m|K]/g, '') : str;
 };

--- a/test.js
+++ b/test.js
@@ -7,6 +7,10 @@ it('should strip color from string', function () {
 	assert.equal(strip('\x1b[0m\x1b[4m\x1b[42m\x1b[31mfoo\x1b[39m\x1b[49m\x1b[24mfoo\x1b[0m'), 'foofoo');
 });
 
+it('should strip color from ls command', function() {
+    assert.equal(strip('\x1b[00;38;5;244m\x1b[m\x1b[00;38;5;33mfoo\x1b[0m'), 'foo');
+});
+
 it('should strip reset;setfg;setbg;italics;strike;underline sequence from string', function () {
 	assert.equal(strip('\x1b[0;33;49;3;9;4mbar\x1b[0m'), 'bar');
 });


### PR DESCRIPTION
Hi there,

Based on the [ANSI escape code Wikipedia article](http://en.wikipedia.org/wiki/ANSI_escape_code), each of the ANSI codes may have up to 3 digits.  I recently [ported this library (and a few of your related libraries) to Python](https://github.com/fgimian/painter) and [this issue](https://github.com/fgimian/painter/issues/1) was reported to me just today so I thought I'd fix it in my library and yours too :smile: 

All the best
Fotis
