### PR TITLE
Support both commonJS and ES module definition in index.d.ts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -12,4 +12,9 @@ stripAnsi('\u001B]8;;https://github.com\u0007Click\u001B]8;;\u0007');
 //=> 'Click'
 ```
 */
-export default function stripAnsi(string: string): string;
+declare var stripAnsi: {
+  (str: string): string;
+  default(str: string): string;
+}
+
+export = stripAnsi;


### PR DESCRIPTION
Disclaimer: I honestly haven't kept up with the whole state of modules these days and this is mostly the result of googling around the last hour or so after our project broke, so I could be pretttttty far off but this is my understanding.

https://github.com/chalk/strip-ansi/commit/89dc7f6b8f4160a1582e0b9a81984d90ddc5ae8f added types to the project 🎉, but the previous typing over at DefinitelyTyped declared the commonJS style (https://github.com/DefinitelyTyped/DefinitelyTyped/blob/8201a5f150d1dbfabf19932d43b64cfb240b1b1c/types/strip-ansi/index.d.ts#L6). It looks like this project supports both (by exporting the function and `.default` on it as well), so this change reflects that in the type.

This also means that anyone updating their project won't have to change their usage, for example, without this change dynamic imports need to go from:  
```const stripAnsi = await import('strip-ansi')``` 
to  
```const stripAnsi = (await import('strip-ansi')).default``` 

Or commonJS requires (because that's what `@types/strip-ansi` had it as before):
```import stripAnsi = require('strip-ansi')``` 
to  
```import stripAnsi from 'strip-ansi'```

Both yell about `Cannot invoke an expression whose type lacks a call signature`.

