### PR TITLE
perf: only create regex once

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,5 +6,6 @@ export default function stripAnsi(string) {
 		throw new TypeError(`Expected a \`string\`, got \`${typeof string}\``);
 	}
 
+	re.lastIndex = 0;
 	return string.replace(re, '');
 }

--- a/index.js
+++ b/index.js
@@ -7,6 +7,5 @@ export default function stripAnsi(string) {
 		throw new TypeError(`Expected a \`string\`, got \`${typeof string}\``);
 	}
 
-	regex.lastIndex = 0;
 	return string.replace(regex, '');
 }

--- a/index.js
+++ b/index.js
@@ -1,9 +1,10 @@
 import ansiRegex from 'ansi-regex';
 
+const re = ansiRegex();
 export default function stripAnsi(string) {
 	if (typeof string !== 'string') {
 		throw new TypeError(`Expected a \`string\`, got \`${typeof string}\``);
 	}
 
-	return string.replace(ansiRegex(), '');
+	return string.replace(re, '');
 }

--- a/index.js
+++ b/index.js
@@ -7,8 +7,8 @@ export default function stripAnsi(string) {
 		throw new TypeError(`Expected a \`string\`, got \`${typeof string}\``);
 	}
 
-	// Even though the regex is global, we don't need to reset the lastIndex
-	// because unlike exec/test, replace does it automatically and doing it manually
-	// has a perf penalty.
+	// Even though the regex is global, we don't need to reset the `.lastIndex`
+	// because unlike `.exec()` and `.test()`, `.replace()` does it automatically
+	// and doing it manually has a performance penalty.
 	return string.replace(regex, '');
 }

--- a/index.js
+++ b/index.js
@@ -7,5 +7,8 @@ export default function stripAnsi(string) {
 		throw new TypeError(`Expected a \`string\`, got \`${typeof string}\``);
 	}
 
+	// Even though the regex is global, we don't need to reset the lastIndex
+	// because unlike exec/test, replace does it automatically and doing it manually
+	// has a perf penalty.
 	return string.replace(regex, '');
 }


### PR DESCRIPTION
With https://github.com/chalk/wrap-ansi/pull/51, a large portion of the time in wrap-ansi is now spent in ansiRegex because strip-ansi creates a new regex on every call and it's called for every word in wrap-ansi.

Before:
![image](https://github.com/chalk/strip-ansi/assets/50981692/68a14735-b608-4abc-9803-59e1a17d6de2)


After:
![image](https://github.com/chalk/strip-ansi/assets/50981692/a063c7cc-7a85-42d4-adf0-2454f987824b)

